### PR TITLE
feat(ui): implement light/dark mode toggle with persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -687,3 +687,5 @@ async function copyURL() {
 
 // ===== Start =====
 init();
+
+

--- a/app.js
+++ b/app.js
@@ -687,5 +687,3 @@ async function copyURL() {
 
 // ===== Start =====
 init();
-
-

--- a/index.html
+++ b/index.html
@@ -42,7 +42,13 @@
         <a href="#setup" class="nav-link">Setup</a>
       </div>
       <div class="nav-buttons">
-        <button class="nav-btn">Theme switch</button>
+        <!-- <button class="nav-btn">Theme switch</button> -->
+        <button id="theme-toggle" class="nav-btn" aria-label="Toggle theme">
+          <svg id="theme-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        </button>
         <button class="nav-btn">Il8n switch</button>
         <a href="https://github.com/aradhyacp/LifeGrid" class="nav-github nav-link" target="_blank"
           rel="noopener noreferrer" aria-label="LifeGrid on GitHub">
@@ -597,6 +603,7 @@
   </footer>
 
   <script type="module" src="app.js"></script>
+  <script src="theme.js"></script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "LifeGrid",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/styles.css
+++ b/styles.css
@@ -21,14 +21,6 @@
   --gray-900: #171717;
   --gray-950: #0A0A0A;
 
-  /* Default to Dark Mode colors (based on your screenshot) */
-  --bg-color: #000000;
-  --text-color: #ffffff;
-  --button-hover: #333333;
-  
-  /* Smooth transition for the whole page */
-  --transition-speed: 0.3s;
-
   /* Accent - can be overridden */
   --accent: #FFFFFF;
 

--- a/styles.css
+++ b/styles.css
@@ -96,8 +96,6 @@ body {
   color: var(--text);
   line-height: 1.6;
   overflow-x: hidden;
-  background-color: var(--bg-color);
-  color: var(--text-color);
   transition: background-color var(--transition-speed), color var(--transition-speed);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,14 @@
   --gray-900: #171717;
   --gray-950: #0A0A0A;
 
+  /* Default to Dark Mode colors (based on your screenshot) */
+  --bg-color: #000000;
+  --text-color: #ffffff;
+  --button-hover: #333333;
+  
+  /* Smooth transition for the whole page */
+  --transition-speed: 0.3s;
+
   /* Accent - can be overridden */
   --accent: #FFFFFF;
 
@@ -88,7 +96,12 @@ body {
   color: var(--text);
   line-height: 1.6;
   overflow-x: hidden;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color var(--transition-speed), color var(--transition-speed);
 }
+
+
 
 /* === Noise Texture Overlay === */
 .noise {
@@ -1517,4 +1530,171 @@ body {
     position: relative;
     top: 0;
   }
+}
+
+
+/* =========================================
+   Light Mode Overrides
+   ========================================= */
+
+body.light-mode {
+  /* 1. Invert the Semantic Colors */
+  --bg: #ffffff;             /* was var(--black) */
+  --bg-elevated: #f3f4f6;    /* was var(--gray-950) */
+  
+  --text: #171717;           /* was var(--white) */
+  --text-secondary: #525252; /* was var(--gray-400) */
+  --text-muted: #a3a3a3;     /* was var(--gray-600) */
+  
+  --border: rgba(0, 0, 0, 0.1);
+  --border-strong: rgba(0, 0, 0, 0.2);
+  
+  --accent: #000000;         /* Invert accent to black */
+}
+
+/* =========================================
+   Light Mode - Professional & Modern Polish
+   ========================================= */
+
+body.light-mode {
+  /* --- 1. Refined Palette (Apple-style Soft Whites) --- */
+  --bg: #ffffff;              /* Pure white page background */
+  --bg-color: #ffffff;
+  --bg-elevated: #f5f5f7;     /* Very subtle grey for contrast areas */
+  
+  --text: #111827;            /* Deep charcoal, softer than pure black */
+  --text-color: #111827;
+  --text-secondary: #4b5563;  /* Cool grey for subtitles */
+  --text-muted: #9ca3af;      /* Light grey for hints */
+  
+  --border: #e5e7eb;          /* Light border */
+  --border-strong: #d1d5db;   /* slightly darker border for inputs */
+  
+  --accent: #000000;          /* Strong accent */
+}
+
+/* --- 2. Fix the "Invisible" Input Fields --- */
+/* This forces inputs to be White with Dark Text */
+body.light-mode .config-select, 
+body.light-mode .config-input,
+body.light-mode .url-input,
+body.light-mode .color-input-wrapper,
+body.light-mode .device-btn {
+  background-color: #ffffff;
+  border-color: var(--border-strong);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05); /* Subtle depth */
+}
+
+body.light-mode .select-arrow {
+  color: var(--text-secondary);
+}
+
+body.light-mode .color-hex {
+  color: var(--text-secondary);
+}
+
+body.light-mode .preset-btn {
+  background: #ffffff;
+  border-color: var(--border);
+}
+
+/* --- 3. Card "Pop" (Depth & Shadows) --- */
+/* Makes cards stand out against the white background */
+body.light-mode .type-card {
+  background: #ffffff;
+  border-color: var(--border);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02), 0 2px 4px -1px rgba(0, 0, 0, 0.02);
+  transition: all 0.3s ease;
+}
+
+body.light-mode .type-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08);
+  border-color: var(--text-muted);
+}
+
+/* Visual Area (Top of card) - Subtle Grey */
+body.light-mode .type-card-visual {
+  background-color: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+}
+
+/* --- 4. Fix Grid/Dot Visibility --- */
+/* Empty dots are faint grey, filled dots are dark charcoal */
+body.light-mode .year-grid-preview .cell,
+body.light-mode .life-grid-preview .dot {
+  background: #e5e7eb; 
+}
+
+body.light-mode .year-grid-preview .cell.filled,
+body.light-mode .life-grid-preview .dot.filled {
+  background: var(--text);
+}
+
+/* Fix Goal Circle (SVG Stroke) */
+body.light-mode .goal-circle-bg { stroke: #e5e7eb; }
+body.light-mode .goal-circle-progress { stroke: var(--text); }
+
+/* --- 5. Selected State Logic --- */
+body.light-mode .type-card.selected {
+  border-color: var(--text);
+  box-shadow: 0 0 0 2px var(--text), 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+body.light-mode .type-card.selected .type-select-btn {
+  background: var(--text);
+  color: #ffffff;
+  border-color: var(--text);
+}
+
+body.light-mode .type-select-btn:hover {
+  background: var(--bg-elevated);
+  color: var(--text);
+  border-color: var(--text);
+}
+
+/* --- 6. Section & Text Fixes --- */
+/* Adds a very subtle gradient to the Customize section to separate it */
+body.light-mode .customize-section {
+  background: linear-gradient(180deg, #fafafa 0%, #ffffff 100%);
+  border-top-color: var(--border);
+}
+
+body.light-mode .hero-title-accent {
+  background: linear-gradient(135deg, #000000 0%, #666666 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+body.light-mode .nav {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+
+body.light-mode .nav-logo { color: var(--text); }
+body.light-mode .footer-github .github-footer-href { color: var(--text-secondary); }
+body.light-mode .noise { filter: invert(1); opacity: 0.03; }
+
+
+/* --- Fix Navigation Hovers in Light Mode --- */
+
+/* 1. Make text turn Dark on hover (instead of White) */
+body.light-mode .nav-link:hover,
+body.light-mode .nav-github:hover {
+  color: var(--text); /* Uses the dark charcoal color (#111827) */
+}
+
+/* 2. Make the underline effect Dark (instead of White) */
+body.light-mode .nav-link::after {
+  background: var(--text);
+}
+
+/* 3. Fix the "Theme Switch" & "I18n" buttons on hover */
+body.light-mode .nav-btn:hover {
+  background-color: var(--bg-elevated); /* Light grey background */
+  color: var(--text);                   /* Dark text */
+  border-color: var(--border-strong);
 }

--- a/theme.js
+++ b/theme.js
@@ -3,6 +3,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeIcon = document.getElementById('theme-icon');
   const body = document.body;
 
+  // If required DOM elements are missing, abort initialization to avoid errors.
+  if (!toggleBtn || !themeIcon) {
+    return;
+  }
   // FIX: Only store the 'inner' HTML (paths), NOT the full <svg> tag
   const sunContent = `
     <circle cx="12" cy="12" r="5"></circle>

--- a/theme.js
+++ b/theme.js
@@ -29,6 +29,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (savedTheme === 'light') {
     body.classList.add('light-mode');
     themeIcon.innerHTML = sunContent;
+  } else {
+    // Ensure the dark mode icon is explicitly set for non-light or unset themes
+    themeIcon.innerHTML = moonContent;
   }
 
   // 2. Toggle Event Listener

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleBtn = document.getElementById('theme-toggle');
+  const themeIcon = document.getElementById('theme-icon');
+  const body = document.body;
+
+  // FIX: Only store the 'inner' HTML (paths), NOT the full <svg> tag
+  const sunContent = `
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  `;
+  
+  const moonContent = `
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  `;
+
+  // 1. Check Local Storage on Load
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'light') {
+    body.classList.add('light-mode');
+    themeIcon.innerHTML = sunContent;
+  }
+
+  // 2. Toggle Event Listener
+  toggleBtn.addEventListener('click', () => {
+    body.classList.toggle('light-mode');
+
+    // We swap the innerHTML of the existing SVG, keeping size/classes intact
+    if (body.classList.contains('light-mode')) {
+      localStorage.setItem('theme', 'light');
+      themeIcon.innerHTML = sunContent;
+    } else {
+      localStorage.setItem('theme', 'dark');
+      themeIcon.innerHTML = moonContent;
+    }
+  });
+});


### PR DESCRIPTION
This PR addresses Issue #17 by adding a fully functional Light/Dark mode toggle to the frontend.

✅ Changes Made
  - HTML : Replaced the placeholder button with a functional toggle using the existing `nav-btn` class for consistent styling.
  - CSS : Implemented a robust `light-mode` theme using CSS variables.
  - Added specific overrides for input visibility, card shadows, and navigation hover states to ensure accessibility in Light Mode.
  - Fixed issues where white text would disappear against white backgrounds.
  - JS : Added logic to toggle the theme, swap the SVG icon (Sun/Moon), and persist the user's preference via `localStorage`.

✅Screenshots
  Dark Mode (Default) 
<img width="1359" height="684" alt="Screenshot 2026-01-31 193525" src="https://github.com/user-attachments/assets/dc9227f2-52ae-4858-9fce-e510114ee914" />
<img width="1359" height="677" alt="Screenshot 2026-01-31 193613" src="https://github.com/user-attachments/assets/7106f722-ac6e-447e-bf79-cc10077e4f76" />

  Light Mode (New)
<img width="1359" height="680" alt="Screenshot 2026-01-31 193540" src="https://github.com/user-attachments/assets/60031f73-b252-40b9-b89e-459f48facadb" />
<img width="1359" height="679" alt="Screenshot 2026-01-31 193559" src="https://github.com/user-attachments/assets/d8ca5e70-a8fe-42d5-b952-eef08d2fbc71" />


✅ Checklist
- 👀My code follows the style guidelines of this project
- 👀 I have performed a self-review of my own code
- 👀 I have commented my code, particularly in hard-to-understand areas